### PR TITLE
Engine api v2 compatibility

### DIFF
--- a/apps/recommend/views.py
+++ b/apps/recommend/views.py
@@ -79,7 +79,7 @@ def get_recommend_context_data(view, context, **kwargs):
             tool_consumer_instance_guid=settings.DEFAULT_TOOL_CONSUMER_INSTANCE_GUID
         ),
         collection=collection.collection_id,
-        sequence='placeholder',  # TODO remove this when engine endpoint ready
+        sequence=[],  # TODO remove this when engine endpoint ready
     )
     r = api.recommend(**data)
     if not r.ok:

--- a/apps/recommend/views.py
+++ b/apps/recommend/views.py
@@ -79,7 +79,7 @@ def get_recommend_context_data(view, context, **kwargs):
             tool_consumer_instance_guid=settings.DEFAULT_TOOL_CONSUMER_INSTANCE_GUID
         ),
         collection=collection.collection_id,
-        sequence=[],  # TODO remove this when engine endpoint ready
+        sequence=[],
     )
     r = api.recommend(**data)
     if not r.ok:

--- a/apps/recommend/views.py
+++ b/apps/recommend/views.py
@@ -78,9 +78,7 @@ def get_recommend_context_data(view, context, **kwargs):
             user_id=view.request.session.get('lti_user_id', 'placeholder'),
             tool_consumer_instance_guid=settings.DEFAULT_TOOL_CONSUMER_INSTANCE_GUID
         ),
-        collection=dict(
-            collection_id=collection.collection_id
-        ),
+        collection=collection.collection_id,
         sequence='placeholder',  # TODO remove this when engine endpoint ready
     )
     r = api.recommend(**data)

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -32,3 +32,8 @@ INSTALLED_APPS += [
 # https://github.com/ottoyiu/django-cors-headers#configuration
 # You may want to explicitly specify allowed origin hostnames in production with CORS_ORIGIN_WHITELIST.
 CORS_ORIGIN_ALLOW_ALL = True
+
+# adaptive engine settings
+ENGINE_URL = os.getenv('ENGINE_URL', 'http://engine:8000')
+ENGINE_TOKEN = os.getenv('ENGINE_TOKEN', '5ea0b01ea8ee0fc0b7cc47160cf4c91fe0447779')
+DEFAULT_TOOL_CONSUMER_INSTANCE_GUID = os.getenv('DEFAULT_TOOL_CONSUMER_INSTANCE_GUID', 'openedx.gse.harvard.edu')


### PR DESCRIPTION
Adjust recommendation API call to engine to follow [engine api v2.0.0 specification](https://app.swaggerhub.com/apis/alosi/engine/2.0.0), and remove placeholder for sequence argument since [engine 2.0.0](https://github.com/harvard-vpal/adaptive-engine/releases/tag/2.0.0) expects a list instead of a placeholder string.
